### PR TITLE
Patch download URL to branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:20 as step1
 RUN mkdir /kitsune && \
     cd /kitsune && \
-    curl https://github.com/kitsune-soc/kitsune/archive/refs/heads/main.zip -Lo main.zip && \
+    curl https://github.com/kitsune-soc/kitsune/archive/refs/heads/allocation-strategy-config.zip -Lo main.zip && \
     unzip main.zip && \
     cd kitsune-main/kitsune-fe && \
     yarn install && \


### PR DESCRIPTION
This is just a draft so you have the changes to try out.  
The patch is using the source from [this PR](https://github.com/kitsune-soc/kitsune/pull/546).

That way you can try out if your weird stack pool creation issue was a problem with the wasmtime allocation strategy.